### PR TITLE
feat: verify the generated parser by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 inputs:
   generate:
     description: Verify the generated parser
-    default: "false"
+    default: "true"
   test-parser:
     description: Test the parser
     default: "true"


### PR DESCRIPTION
Enables check to ensure `parser.c` matches `tree-sitter generate` output by default. The intent is to ensure downstream parser repos which use this action default to running this check on PRs to avoid malicious code being smuggled inside of `parser.c`.

cc @amaanq