### PR TITLE
fix(zig): fix non-existent reference to zig@v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ swift-version:
 test-zig:
   description: Test the Zig bindings
   default: false
-swift-version:
+zig-version:
   description: Zig version
   default: "0.15.1"
 ```

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,7 @@ runs:
       with:
         swift-version: ${{inputs.swift-version}}
     - name: Run Zig tests
-      uses: tree-sitter/parser-test-action/zig@v2
+      uses: tree-sitter/parser-test-action/zig@master
       if: inputs.test-zig == 'true'
       with:
         zig-version: ${{inputs.zig-version}}


### PR DESCRIPTION
The action references `uses: tree-sitter/parser-test-action/zig@v2` but this file does not exist with the v2 tag. This results in CI failure if you try to use the `parser-test-action`, even if you don't try to use the new zig functionality.

Fix the reference to use `master` which is valid.
Fix README typo of `zig-version`.