### PR TITLE
Update default Go version to 1.23 in main action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
     default: "false"
   go-version:
     description: Go version
-    default: "1.22"
+    default: "1.23"
   test-swift:
     description: Test the Swift bindings
     default: "false"


### PR DESCRIPTION
It looks like Go 1.23 is now required to test Go bindings. The default version of Go in go/action.yml was updated to 1.23 with

https://github.com/tree-sitter/parser-test-action/commit/076fb73d3c9f89081f39e8438c1fb7211e3e5c84#diff-0fa20ca55c6a24608e321568a4c30be88dccab7251c65a72bfa296fbf5f5a2a3

but it’s still 1.22 in the main action.yml file. This causes tests of Go bindings to fail:

https://github.com/nwhetsell/tree-sitter-lilypond/actions/runs/17735451454/job/50395973398#step:4:875

This PR updates the default Go version in the main action.yml file.